### PR TITLE
handle malformed or nonexistent start_sha

### DIFF
--- a/gitapi.py
+++ b/gitapi.py
@@ -239,7 +239,12 @@ def get_commit_list(repo_key):
         start_commit_id = _lookup_ref(repo, ref_name).resolve().oid
 
     commits = []
-    walker = repo.walk(start_commit_id, GIT_SORT_TIME)
+    try:
+        walker = repo.walk(start_commit_id, GIT_SORT_TIME)
+    except ValueError:
+        raise BadRequest("invalid start_sha")
+    except KeyError:
+        raise NotFound("commit not found")
     count = 0
     for commit in walker:
         count += 1


### PR DESCRIPTION
Currently, hitting `http://localhost:5000/repos/restfulgit/git/commits?start_sha=qwerty` or `http://localhost:5000/repos/restfulgit/git/commits?start_sha=123456789` results in a 500 error. This fixes that.
