### PR TITLE
gitapi module => restfulgit package

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = restfulgit
+omit =
+    */tests/*
+    */__main__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - "export LIBGIT2='/usr/local'"
   - "export LDFLAGS=\"-Wl,-rpath='$LIBGIT2/lib',--enable-new-dtags $LDFLAGS\""
 before_script:
-  - "pip install --use-mirrors pep8 'pylint<1.0.0' Flask-Testing nose"
+  - "pip install --use-mirrors pep8 'pylint<1.0.0' Flask-Testing coverage nose coveralls"
   - "pip install --use-mirrors filemagic"
   - "git fetch --unshallow || true"
   - "git fetch --all"
@@ -21,6 +21,9 @@ before_script:
   - "git branch -v"
   - "git checkout -b master || true"
 script:
-  - "pep8 *.py"
-  - "pylint --rcfile=pylint.rc *.py"
-  - "nosetests"
+  - "pep8 restfulgit"
+  - "pylint --rcfile=pylint.rc restfulgit"
+  - "nosetests --with-xunit --failure-detail"
+  - "PYTHONPATH=. coverage run tests/test_restfulgit.py"
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 RestfulGit: A Restful API for Git data
 =======================================
 [![Build Status](https://travis-ci.org/hulu/restfulgit.png?branch=master)](https://travis-ci.org/hulu/restfulgit)
+[![Coverage Status](https://coveralls.io/repos/hulu/restfulgit/badge.png?branch=master)](https://coveralls.io/r/hulu/restfulgit?branch=master)
 [![Requirements Status](https://requires.io/github/hulu/restfulgit/requirements.png?branch=master)](https://requires.io/github/hulu/restfulgit/requirements/?branch=master)
 
 Provides a read-only restful interface for accessing data from Git repositories (local to the server).
@@ -16,10 +17,11 @@ Must modify: `config.conf` : `repo_base_path` (root path for repositories; note:
 Optional:
 - filemagic (= 1.6) (offers improved MIME-type guessing), which itself requires libmagic (= 5.11)
 
-`gitapi.py` is a valid WSGI application.
+The `restfulgit` package is a valid WSGI application.
 
-While the app can be run with `python gitapi.py` -- this runs Flask in debug mode and should NOT be used in production.
-Instead the app can be run with any WSGI server, such as gunicorn (`pip install gunicorn; gunicorn gitapi`)
+While the app can be run with `python -m restfulgit` -- this runs Flask in debug mode and should NOT be used in production.
+Instead, the app can be run with any WSGI server, such as gunicorn (`pip install gunicorn; gunicorn restfulgit`)
+(Note: If you haven't installed restfulgit into your Python environment, you may need to explicitly set `PYTHONPATH` when running the above commands.)
 
 --
 

--- a/pylint.rc
+++ b/pylint.rc
@@ -12,7 +12,7 @@ profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,tests
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/restfulgit/__init__.py
+++ b/restfulgit/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2.7
 # coding=utf-8
 from __future__ import print_function
 
@@ -506,10 +505,5 @@ def index():  # pragma: no cover
 
 
 app.register_blueprint(restfulgit)
-
-if __name__ == '__main__':  # pragma: no cover
-    app.debug = True
-    app.run(host="0.0.0.0")
-
 
 application = app

--- a/restfulgit/__main__.py
+++ b/restfulgit/__main__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python2.7
+# coding=utf-8
+
+from restfulgit import app
+
+app.debug = True
+app.run(host="0.0.0.0")


### PR DESCRIPTION
- Switches from a module to a package
  - More in line with other projects
  - We'll need to do this anyway when we go multi-module (e.g. for `/commits/` support)
- Names that package `restfulgit` for consistency
- Also enables [Coveralls code coverage tracking.](https://coveralls.io/r/hulu/restfulgit) (We're currently at 89%)

/cc @dlindquist @rajivm for code review
